### PR TITLE
Workaround off DawnCC build problem in build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,53 +46,15 @@ Note that, since most implementations are premiliminary and tend to change consi
 
 ## Installation
 
-The project is structured as a set of dynamically loaded libraries/passes for LLVM that can be built separately from the main compiler. However, an existing LLVM build (compiled using cmake) is necessary to build our code. The base LLVM version used in this project was LLVM 3.7 release:
+The project is structured as a set of dynamically loaded libraries/passes for LLVM that can be built separately from the main compiler. However, an existing LLVM build (compiled using cmake) is necessary to build our code. 
 
-[LLVM](http://llvm.org/releases/3.7.0/llvm-3.7.0.src.tar.xz)
-
-[Clang](http://llvm.org/releases/3.7.0/cfe-3.7.0.src.tar.xz)
-
-This project also requires some changes to be applied to LLVM itself. To do so, apply the patch "llvm-patch.diff" to your LLVM source directory. This patch can be found in 'ArrayInference/llvm-patch.diff'.
-
-After applying the diff, we can move on to compiling a fresh LLVM+Clang 3.7 build. To do so, you can follow these outlines:
-
-	MAKEFLAG="-j8"
-  
- 	LLVM_SRC=<path-to-llvm-source-folder>
-	REPO=<path-to-dawncc-repository>
-
-	#We will build a debug version of LLVM+Clang under ${LLVM_SRC}/../llvm-build
-	mkdir ${LLVM_SRC}/../llvm-build
-	cd ${LLVM_SRC}/../llvm-build
-
-	#Setup clang plugins to be compiled alongside LLVM and Clang
-	${REPO}/src/ScopeFinder/setup.sh
-
-	#Create build setup for LLVM+Clang using CMake
-	cmake -DCMAKE_BUILD_TYPE=debug -DBUILD_SHARED_LIBS=ON ${LLVM_SRC}
-	
-	#Compile LLVM+Clang (this will likely take a while)
-	make ${MAKEFLAG}
-	cd -
-
-After you get a fresh LLVM build under ${LLVM_BUILD_DIR}, the following commands can be used to build DawnCC:
-
-	LLVM_BUILD_DIR=<path-to-llvm-build-folder> 	
-	REPO=<path-to-repository>
-
- 	# Build the shared libraries under ${REPO}/lib, assumming an existing LLVM
- 	# build under ${LLVM_BUILD_DIR}
- 	mkdir ${REPO}/lib
- 	cd ${REPO}/lib
- 	cmake -DLLVM_DIR=${LLVM_BUILD_DIR}/share/llvm/cmake ../src/
- 	make
-	cd -
+To download and build both LLVM/Clang and DawnCC, download and run only the [bash script](https://github.com/Gabrielcarvfer/DawnCC-Compiler/blob/master/build.sh) on the folder you want the source to be downloaded and built. You will need CMake, wget, unzip, tar and a toolchain to run it.
 
 ## How to run a code
 
 To run DawnCC, copy and paste the text below into a shell script file. You will have to change text between pointy brackets, e.g., *< like this >* to adapt the script to your environment.
 
- 	LLVM_PATH=<path-to-llvm-build-bin-folder>
+ 	LLVM_PATH="<root folder>/llvm-build/bin"
 
  	export CLANG="$LLVM_PATH/clang"
  	export CLANGFORM="$LLVM_PATH/clang-format"

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Or you can build it manually by downloading [LLVM](http://llvm.org/releases/3.7.
 
 ## How to run a code
 
-To run DawnCC, you can run the run.sh bash script, passing as arguments the directory which llvm-build and DawnCC are located and a directory containing source files to be processed (currently single level folder, not recursive). Arguments can be passed in command line to change behaviour of the script.
+To run DawnCC, you can run the run.sh bash script, passing as arguments the directory which llvm-build and DawnCC are located and a directory containing source files to be processed. Arguments can be passed in command line to change behaviour of the script.
     
     ./run.sh -d <root folder> -src <folder with files to be processed> 
 

--- a/README.md
+++ b/README.md
@@ -52,49 +52,53 @@ You can download and build both LLVM/Clang and DawnCC using the following the [b
 
 Or you can build it manually by doing the following:
 
-Download [LLVM](http://llvm.org/releases/3.7.0/llvm-3.7.0.src.tar.xz) and [Clang](http://llvm.org/releases/3.7.0/cfe-3.7.0.src.tar.xz).
+    Download [LLVM](http://llvm.org/releases/3.7.0/llvm-3.7.0.src.tar.xz) and [Clang](http://llvm.org/releases/3.7.0/cfe-3.7.0.src.tar.xz).
 
-Extract their contents to llvm and llvm/tools/clang.
+    Extract their contents to llvm and llvm/tools/clang.
 
-Download the DawnCC source and apply the patch "llvm-patch.diff" to your LLVM source directory, that is located in 'ArrayInference/llvm-patch.diff'.
+    Download the DawnCC source and apply the patch "llvm-patch.diff" to your LLVM source directory, that is located in 'ArrayInference/llvm-patch.diff'.
 
-After applying the diff, we can move on to compiling a fresh LLVM+Clang 3.7 build. To do so, you can follow these outlines:
+    After applying the diff, we can move on to compiling a fresh LLVM+Clang 3.7 build. To do so, you can follow these outlines:
 
-	MAKEFLAG="-j8"
-  
- 	LLVM_SRC=<path-to-llvm-source-folder>
-	REPO=<path-to-dawncc-repository>
+    	MAKEFLAG="-j8"
+      
+     	LLVM_SRC=<path-to-llvm-source-folder>
+    	REPO=<path-to-dawncc-repository>
 
-	#We will build a debug version of LLVM+Clang under ${LLVM_SRC}/../llvm-build
-	mkdir ${LLVM_SRC}/../llvm-build
-	cd ${LLVM_SRC}/../llvm-build
+    	#We will build a debug version of LLVM+Clang under ${LLVM_SRC}/../llvm-build
+    	mkdir ${LLVM_SRC}/../llvm-build
+    	cd ${LLVM_SRC}/../llvm-build
 
-	#Setup clang plugins to be compiled alongside LLVM and Clang
-	${REPO}/src/ScopeFinder/setup.sh
+    	#Setup clang plugins to be compiled alongside LLVM and Clang
+    	${REPO}/src/ScopeFinder/setup.sh
 
-	#Create build setup for LLVM+Clang using CMake
-	cmake -DCMAKE_BUILD_TYPE=debug -DBUILD_SHARED_LIBS=ON ${LLVM_SRC}
-	
-	#Compile LLVM+Clang (this will likely take a while)
-	make ${MAKEFLAG}
-	cd -
+    	#Create build setup for LLVM+Clang using CMake
+    	cmake -DCMAKE_BUILD_TYPE=debug -DBUILD_SHARED_LIBS=ON ${LLVM_SRC}
+    	
+    	#Compile LLVM+Clang (this will likely take a while)
+    	make ${MAKEFLAG}
+    	cd -
 
-After you get a fresh LLVM build under ${LLVM_BUILD_DIR}, the following commands can be used to build DawnCC:
+    After you get a fresh LLVM build under ${LLVM_BUILD_DIR}, the following commands can be used to build DawnCC:
 
-	LLVM_BUILD_DIR=<path-to-llvm-build-folder> 	
-	REPO=<path-to-repository>
+    	LLVM_BUILD_DIR=<path-to-llvm-build-folder> 	
+    	REPO=<path-to-repository>
 
- 	# Build the shared libraries under ${REPO}/lib, assumming an existing LLVM
- 	# build under ${LLVM_BUILD_DIR}
- 	mkdir ${REPO}/lib
- 	cd ${REPO}/lib
- 	cmake -DLLVM_DIR=${LLVM_BUILD_DIR}/share/llvm/cmake ../src/
- 	make
-	cd -
+     	# Build the shared libraries under ${REPO}/lib, assumming an existing LLVM
+     	# build under ${LLVM_BUILD_DIR}
+     	mkdir ${REPO}/lib
+     	cd ${REPO}/lib
+     	cmake -DLLVM_DIR=${LLVM_BUILD_DIR}/share/llvm/cmake ../src/
+     	make
+    	cd -
 
 ## How to run a code
 
-To run DawnCC, copy and paste the text below into a shell script file. You will have to change text between pointy brackets, e.g., *< like this >* to adapt the script to your environment.
+To run DawnCC, you can run the run.sh bash script, passing as arguments the directory which llvm-build and DawnCC are located and a directory containing source files to be processed (currently single level folder, not recursive). Arguments can be passed in command line to change behaviour of the script.
+    
+    ./run.sh -d <root folder> -src <folder with files to be processed> 
+
+Or you can run DawnCC by copying and pasting the text below into a shell script file. You will have to change text between pointy brackets, e.g., *< like this >* to adapt the script to your environment.
 
  	LLVM_PATH="<root folder>/llvm-build/bin"
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,7 @@ The project is structured as a set of dynamically loaded libraries/passes for LL
 
 You can download and build both LLVM/Clang and DawnCC using the following the [bash script](https://github.com/gleisonsdm/DawnCC-Compiler/blob/master/build.sh) on the folder you want the source to be downloaded and built. You will need CMake, wget, unzip, tar and a toolchain to run it.
 
-Or you can build it manually by doing the following:
-
-    Download [LLVM](http://llvm.org/releases/3.7.0/llvm-3.7.0.src.tar.xz) and [Clang](http://llvm.org/releases/3.7.0/cfe-3.7.0.src.tar.xz).
+Or you can build it manually by downloading [LLVM](http://llvm.org/releases/3.7.0/llvm-3.7.0.src.tar.xz) and [Clang](http://llvm.org/releases/3.7.0/cfe-3.7.0.src.tar.xz), then:
 
     Extract their contents to llvm and llvm/tools/clang.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,49 @@ Note that, since most implementations are premiliminary and tend to change consi
 
 The project is structured as a set of dynamically loaded libraries/passes for LLVM that can be built separately from the main compiler. However, an existing LLVM build (compiled using cmake) is necessary to build our code. 
 
-To download and build both LLVM/Clang and DawnCC, download and run only the [bash script](https://github.com/Gabrielcarvfer/DawnCC-Compiler/blob/master/build.sh) on the folder you want the source to be downloaded and built. You will need CMake, wget, unzip, tar and a toolchain to run it.
+You can download and build both LLVM/Clang and DawnCC using the following the [bash script](https://github.com/gleisonsdm/DawnCC-Compiler/blob/master/build.sh) on the folder you want the source to be downloaded and built. You will need CMake, wget, unzip, tar and a toolchain to run it.
+
+Or you can build it manually by doing the following:
+
+Download [LLVM](http://llvm.org/releases/3.7.0/llvm-3.7.0.src.tar.xz) and [Clang](http://llvm.org/releases/3.7.0/cfe-3.7.0.src.tar.xz).
+
+Extract their contents to llvm and llvm/tools/clang.
+
+Download the DawnCC source and apply the patch "llvm-patch.diff" to your LLVM source directory, that is located in 'ArrayInference/llvm-patch.diff'.
+
+After applying the diff, we can move on to compiling a fresh LLVM+Clang 3.7 build. To do so, you can follow these outlines:
+
+	MAKEFLAG="-j8"
+  
+ 	LLVM_SRC=<path-to-llvm-source-folder>
+	REPO=<path-to-dawncc-repository>
+
+	#We will build a debug version of LLVM+Clang under ${LLVM_SRC}/../llvm-build
+	mkdir ${LLVM_SRC}/../llvm-build
+	cd ${LLVM_SRC}/../llvm-build
+
+	#Setup clang plugins to be compiled alongside LLVM and Clang
+	${REPO}/src/ScopeFinder/setup.sh
+
+	#Create build setup for LLVM+Clang using CMake
+	cmake -DCMAKE_BUILD_TYPE=debug -DBUILD_SHARED_LIBS=ON ${LLVM_SRC}
+	
+	#Compile LLVM+Clang (this will likely take a while)
+	make ${MAKEFLAG}
+	cd -
+
+After you get a fresh LLVM build under ${LLVM_BUILD_DIR}, the following commands can be used to build DawnCC:
+
+	LLVM_BUILD_DIR=<path-to-llvm-build-folder> 	
+	REPO=<path-to-repository>
+
+ 	# Build the shared libraries under ${REPO}/lib, assumming an existing LLVM
+ 	# build under ${LLVM_BUILD_DIR}
+ 	mkdir ${REPO}/lib
+ 	cd ${REPO}/lib
+ 	cmake -DLLVM_DIR=${LLVM_BUILD_DIR}/share/llvm/cmake ../src/
+ 	make
+	cd -
 
 ## How to run a code
 

--- a/build.sh
+++ b/build.sh
@@ -52,8 +52,15 @@ fi
 
 
 #If downloaded tarballs were not extracted, then extract
+if [ ! -d "${DAWN_PATH}" ]; then
+    unzip "${DAWN_SRC_FILE}" 
+    mv "${ROOT_FOLDER}/${DAWN_SRC_FILE%%.*}" "${DAWN_PATH}"
+fi
+
 if [ ! -d "${LLVM_SRC}" ]; then
-    tar -Jxf "llvm-${LLVM_VER}.src.tar.xz"
+    mkdir "${LLVM_SRC}"
+    tar -Jxf "llvm-${LLVM_VER}.src.tar.xz" -C "${LLVM_SRC}" --strip 1
+
 
     #Apply DawnCC patch into LLVM source
     cd "${LLVM_SRC}"
@@ -66,9 +73,7 @@ if [ ! -d "${CLANG_SRC}" ]; then
     tar -Jxf "cfe-${CLANG_VER}.src.tar.xz" -C "${CLANG_SRC}" --strip 1 #extract clang tarball to llvm/tools folder
 fi
 
-if [ ! -d "${DAWN_PATH}" ]; then
-    unzip "${DAWN_SRC_FILE}"
-fi
+
 
 #Create output folder for LLVM
 mkdir ${LLVM_OUTPUT_DIR}

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+#You need wget, tar, unzip, cmake and a toolchain to use this script
+#Put this on a root folder, than it will download all tarballs required and build
+#After running, you will have something like
+#
+#./
+#├── build.sh
+#├── cfe-3.7.0.src.tar.xz
+#├── DawnCC
+#├── DawnCC-Compiler-master.zip
+#├── llvm
+#├── llvm-3.7.0.src.tar.xz
+#└── llvm-build
+
+#Number of threads to build
+MAKE_THREADS=8
+
+#Clang and LLVM versions
+LLVM_VER="3.7.0"
+CLANG_VER="3.7.0"
+
+#DawnCC root path plus Clang and LLVM source folders
+ROOT_FOLDER=`pwd`
+DAWN_PATH="${ROOT_FOLDER}/DawnCC"
+LLVM_SRC="${ROOT_FOLDER}/llvm"
+CLANG_SRC="${LLVM_SRC}/tools/clang"
+LLVM_OUTPUT_DIR="${ROOT_FOLDER}/llvm-build"
+
+#Tarball names
+LLVM_SRC_FILE="llvm-${LLVM_VER}.src.tar.xz"
+CLANG_SRC_FILE="cfe-${CLANG_VER}.src.tar.xz"
+DAWN_SRC_FILE="DawnCC-Compiler-master.zip"
+
+#Tarball websites
+LLVM_SRC_ADDR="http://llvm.org/releases/${LLVM_VER}/${LLVM_SRC_FILE}"
+CLANG_SRC_ADDR="http://llvm.org/releases/${CLANG_VER}/${CLANG_SRC_FILE}"
+DAWN_SRC_ADDR="https://github.com/gleisonsdm/DawnCC-Compiler/archive/master.zip"
+
+#Download LLVM, Clang and DawnCC source tarballs if not already downloaded
+if [ ! -f "${LLVM_SRC_FILE}" ]; then
+    wget "${LLVM_SRC_ADDR}"
+fi
+
+if [ ! -f "${CLANG_SRC_FILE}" ]; then
+    wget "${CLANG_SRC_ADDR}"
+fi
+
+if [ ! -f "${DAWN_SRC_FILE}" ]; then
+    wget -O "${DAWN_SRC_FILE}" "${DAWN_SRC_ADDR}" #download master.zip as DawnCC-Compiler-master.zip
+fi
+
+
+#If downloaded tarballs were not extracted, then extract
+if [ ! -d "${LLVM_SRC}" ]; then
+    tar -Jxf "llvm-${LLVM_VER}.src.tar.xz"
+
+    #Apply DawnCC patch into LLVM source
+    cd "${LLVM_SRC}"
+    patch -p1 < "${DAWN_PATH}/ArrayInference/llvm-patch.diff"
+    cd "${ROOT_FOLDER}"
+fi
+
+if [ ! -d "${CLANG_SRC}" ]; then
+    mkdir "${CLANG_SRC}"
+    tar -Jxf "cfe-${CLANG_VER}.src.tar.xz" -C "${CLANG_SRC}" --strip 1 #extract clang tarball to llvm/tools folder
+fi
+
+if [ ! -d "${DAWN_PATH}" ]; then
+    unzip "${DAWN_SRC_FILE}"
+fi
+
+#Create output folder for LLVM
+mkdir ${LLVM_OUTPUT_DIR}
+
+#Setup LLVM+Clang and plugins
+${DAWN_PATH}/ScopeFinder/setup.sh
+
+#Create setup with cmake
+cd ${LLVM_OUTPUT_DIR}
+cmake -DCMAKE_BUILD_TYPE=debug -DBUILD_SHARED_LIBS=ON ${LLVM_SRC}
+
+#Build LLVM and Clang
+make -j${MAKE_THREADS}
+cd ${ROOT_FOLDER}
+
+#Create lib folder of DawnCC
+mkdir ${DAWN_PATH}/lib 
+
+#Navigate and create setup
+cd ${DAWN_PATH}/lib
+cmake -DLLVM_DIR=${LLVM_OUTPUT_DIR}/share/llvm/cmake ../
+make -j${MAKE_THREADS}
+
+#Go back to root folder
+cd ${ROOT_FOLDER}

--- a/build.sh
+++ b/build.sh
@@ -78,8 +78,10 @@ fi
 #Create output folder for LLVM
 mkdir ${LLVM_OUTPUT_DIR}
 
-#Setup LLVM+Clang and plugins
-${DAWN_PATH}/ScopeFinder/setup.sh
+#Setup LLVM+Clang and scope-finder plugin
+mkdir -p ${LLVM_SRC}/tools/clang/tools/extra
+echo "add_subdirectory(scope-finder)" > ${LLVM_SRC}/tools/clang/tools/extra/CMakeLists.txt
+cp -rf ${DAWN_PATH}/ScopeFinder/scope-finder ${LLVM_SRC}/tools/clang/tools/extra/.
 
 #Create setup with cmake
 cd ${LLVM_OUTPUT_DIR}

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+#You can use this script to run DawnCC, passing the DawnCC root dir, arguments to change output and files to be processed
+#./run.sh -d (DawnCC root dir - containing DawnCC and llvm-build) -src (folder with *.c and *.cpp files to be processed)
+
+
+#Set default parameters of DawnCC
+CURRENT_DIR=`pwd`
+DEFAULT_ROOT_DIR=`pwd`
+GPUONLY_BOOL="false"
+PARALELLIZE_LOOPS_BOOL="true"
+PRAGMA_STANDARD_INT=1
+POINTER_DESAMBIGUATION_BOOL="true"
+MEMORY_COALESCING_BOOL="true"
+MINIMIZE_ALIASING_BOOL="true"
+CODE_CHANGE_BOOL="true"
+FILES_FOLDER="src"
+
+
+#Process arguments of script
+while [[ $# -gt 1 ]]
+do
+    key="$1"
+
+    case $key in
+        -d|--DawnCCRoot)
+            DEFAULT_ROOT_DIR="$2" #if you pass the DawnCC root dir (folder containing llvm-build and DawnCC, it's not going to assume that you're currently on it)
+            shift # past argument
+        ;;
+        -G|--GpuOnlyAnalysis)
+            GPUONLY_BOOL="$2" # true - analyze only functions with GPU prefix; false - analyze all functions
+            shift # past argument
+        ;;
+        -pl|--ParallelizeLoops)
+            PARALELLIZE_LOOPS_BOOL="$2" #true - try to annotate loops; false - don't annotate loops
+            shift # past argument
+        ;;
+        -ps|--PragmaStandard)
+            PRAGMA_STANDARD_INT="$2" #0-OpenACC; 1-OpenMP GPU; 2-OpenMP CPU
+            shift # past argument
+        ;;
+        -pd|--PointerDesambiguation)
+            POINTER_DESAMBIGUATION_BOOL="$2" #true - annotate tests; false - don't annotate tests
+            shift # past argument
+        ;;
+        -mc|--MemoryCoalescing)
+            MEMORY_COALESCING_BOOL="$2" #true - try to use memory coalescing; false - don't try to use coalescing
+            shift # past argument
+        ;;
+        -ma|--MinimizeAliasing)
+            MINIMIZE_ALIASING_BOOL="$2" #true - use licm in pointer range analysis; false - don't make pointer range analysis
+            shift # past argument
+        ;;
+        -cc|--AllowCodeChange)
+            CODE_CHANGE_BOOL="$2" #true - allow modification to program regions; false - only modify what allowed in LLVM IR
+            shift # past argument
+        ;;
+        -src|--SourceFolder)
+            FILES_FOLDER="$2" # path to be scanned and have files processed
+            shift
+        ;;
+        *)
+            # unknown option
+        ;;
+    esac
+    shift # past argument or value
+done
+
+
+#Export path to llvm and its tools
+LLVM_PATH="${DEFAULT_ROOT_DIR}/llvm-build/"
+export CLANG="${LLVM_PATH}/bin/clang"
+export CLANGFORM="${LLVM_PATH}/bin/clang-format"
+export OPT="${LLVM_PATH}/bin/opt"
+export SCOPEFIND="${LLVM_PATH}/lib/scope-finder.so"
+
+#Export path to DawnCC libraries
+export BUILD="${DEFAULT_ROOT_DIR}/DawnCC/lib"
+export PRA="${BUILD}/PtrRangeAnalysis/libLLVMPtrRangeAnalysis.so"
+export AI="${BUILD}/AliasInstrumentation/libLLVMAliasInstrumentation.so"
+export DPLA="${BUILD}/DepBasedParallelLoopAnalysis/libParallelLoopAnalysis.so"
+export CP="${BUILD}/CanParallelize/libCanParallelize.so"
+export WAI="${BUILD}/ArrayInference/libLLVMArrayInference.so"
+export ST="${BUILD}/ScopeTree/libLLVMScopeTree.so"
+
+#Export tools flags
+export FLAGS="-mem2reg -tbaa -scoped-noalias -basicaa -functionattrs -gvn -loop-rotate
+-instcombine -licm"
+
+export FLAGSAI="-mem2reg -instnamer -loop-rotate"
+
+
+#Temporary files names
+TEMP_FILE1="result.bc"
+TEMP_FILE2="result2.bc"
+TEMP_FILE3="result3.bc"
+
+if [ -f "${TEMP_FILE1}" ]; then
+    rm ${TEMP_FILE1}
+fi
+
+if [ -f "${TEMP_FILE2}" ]; then
+    rm {TEMP_FILE2}
+fi
+
+cd ${FILES_FOLDER}
+
+for f in $(find . -name '*.c' -or -name '*.cpp'); do 
+    $CLANGFORM -style="{BasedOnStyle: llvm, IndentWidth: 2}" -i ${f}
+
+    $CLANG -Xclang -load -Xclang $SCOPEFIND -Xclang -add-plugin -Xclang -find-scope -g -O0 -c -fsyntax-only ${f}
+
+    $CLANG -g -S -emit-llvm ${f} -o ${TEMP_FILE1} 
+
+    $OPT -load $PRA -load $AI -load $DPLA -load $CP $FLAGS -ptr-ra -basicaa \
+      -scoped-noalias -alias-instrumentation -region-alias-checks -can-parallelize -S ${TEMP_FILE1}
+
+    $OPT -load $ST -load $WAI -annotateParallel -S ${TEMP_FILE1} -o ${TEMP_FILE2}
+
+    $OPT -S $FLAGSAI -load $ST -load $WAI -writeInFile -stats -Emit-GPU=${GPUONLY_BOOL} \
+      -Emit-Parallel=${PARALELLIZE_LOOPS_BOOL} -Emit-OMP=${PRAGMA_STANDARD_INT} -Restrictifier=${POINTER_DESAMBIGUATION_BOOL} \
+      -Memory-Coalescing=${MEMORY_COALESCING_BOOL} -Ptr-licm=${MINIMIZE_ALIASING_BOOL} -Ptr-region=${CODE_CHANGE_BOOL} \
+      -Run-Mode=false ${TEMP_FILE2} -o ${TEMP_FILE3}
+
+    #$CLANGFORM -style="{BasedOnStyle: llvm, IndentWidth: 2}" -i "${f}"
+done
+
+cd ${CURRENT_DIR}
+

--- a/run.sh
+++ b/run.sh
@@ -106,6 +106,7 @@ fi
 cd ${FILES_FOLDER}
 
 for f in $(find . -name '*.c' -or -name '*.cpp'); do 
+
     $CLANGFORM -style="{BasedOnStyle: llvm, IndentWidth: 2}" -i ${f}
 
     $CLANG -Xclang -load -Xclang $SCOPEFIND -Xclang -add-plugin -Xclang -find-scope -g -O0 -c -fsyntax-only ${f}
@@ -122,8 +123,9 @@ for f in $(find . -name '*.c' -or -name '*.cpp'); do
       -Memory-Coalescing=${MEMORY_COALESCING_BOOL} -Ptr-licm=${MINIMIZE_ALIASING_BOOL} -Ptr-region=${CODE_CHANGE_BOOL} \
       -Run-Mode=false ${TEMP_FILE2} -o ${TEMP_FILE3}
 
-    #$CLANGFORM -style="{BasedOnStyle: llvm, IndentWidth: 2}" -i "${f}"
+    $CLANGFORM -style="{BasedOnStyle: llvm, IndentWidth: 2}" -i "${f}"
 done
 
 cd ${CURRENT_DIR}
+
 


### PR DESCRIPTION
Hi, sorry to open another request with same topic, but found out that sometimes the ScopeFinder couldn't get compiled with the script because of some dependency problem with Clang. Modified the script to build Clang and then LLVM. 